### PR TITLE
fin du controlleur items sans la methode destroy

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,4 +7,24 @@ class ItemsController < ApplicationController
   @item = Item.find(params[:id])
   end
 
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @item = Item.new(item_params)
+    @item.user = current_user
+    if @item.save!
+    redirect_to item_path(@item)
+    else
+    render :new
+    end
+  end
+
+private
+
+  def item_params
+    params.require(:item).permit(:name, :price)
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -14,7 +14,7 @@ class ItemsController < ApplicationController
   def create
     @item = Item.new(item_params)
     @item.user = current_user
-    if @item.save!
+    if @item.save
     redirect_to item_path(@item)
     else
     render :new

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-   skip_before_action :authenticate_user!, only: :home
+  skip_before_action :authenticate_user!, only: :home
 
   def home
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,5 +2,5 @@ class Item < ApplicationRecord
   belongs_to :user
   has_many :bookings, dependent: :destroy
 
-  validates :name, :price, :size, presence: true
+  validates :name, :price,  presence: true
 end

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for @item do |f| %>
+  <%= f.input :name %>
+  <%= f.input :price %>
+  <%= f.input :size %>
+  <%= f.submit %>
+<% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Ici c'est la show</h1>
 
 <%= @item.name %>
+<%= @item.price %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :items, only: [:index, :show]
+  resources :items, only: [:index, :show, :new, :create]
 end


### PR DESCRIPTION
Creation du controleur items + les routes associées et verifiées. 
Il manque la méthode destroy de ce controleur. 
